### PR TITLE
Sign-magnitude to Two's complement (4bits)

### DIFF
--- a/sm-to-2comp.v
+++ b/sm-to-2comp.v
@@ -1,0 +1,18 @@
+/* ----- ----- ----- ----- ----- -----
+	Design: 4bit sign-magnitude to 2's complement
+			By using primitives
+ 	Filename: sm_to_2comp.v
+	Coder: Gabriel Maruschi
+ 	Versions: /july_2024/
+	----- ----- ----- ----- ----- -----
+*/ 
+
+module sm_to_2comp(y, j);
+  output [3:0] y;
+  input [3:0] j;
+  
+  assign y [3] = (j [3] & j [2]) | (j [3] & j [1]) | (j [3] & j [0]);
+  assign y [2] = ((~ j [3]) & j [2]) | (j [2] & (~ j [1]) & (~ j [0])) | (j [3] & (~ j[2]) & j [0]) | (j [3] & (~ j [2]) & j [1]);
+  assign y [1] = ((~ j [3]) & j [1]) | (j [1] & (~ j [0])) | (j [3] & (~ j [1]) & j [0]);
+  assign y [0] = j [0];
+endmodule

--- a/sm-to-2comp_tb.v
+++ b/sm-to-2comp_tb.v
@@ -1,7 +1,7 @@
 /* ----- ----- ----- ----- ----- -----
 	Design: 4bit sign-magnitude to 2's complement
 			By using primitives -- TESTBENCH
- 	Filename: sm_to_2comp.v
+ 	Filename: sm-to-2comp_tb.v
 	Coder: Gabriel Maruschi
  	Versions: /july_2024/
 	----- ----- ----- ----- ----- -----

--- a/sm-to-2comp_tb.v
+++ b/sm-to-2comp_tb.v
@@ -1,0 +1,37 @@
+/* ----- ----- ----- ----- ----- -----
+	Design: 4bit sign-magnitude to 2's complement
+			By using primitives -- TESTBENCH
+ 	Filename: sm_to_2comp.v
+	Coder: Gabriel Maruschi
+ 	Versions: /july_2024/
+	----- ----- ----- ----- ----- -----
+*/ 
+
+`timescale 1 ns/100 ps
+`include "sm-to-2comp.v"
+
+module sm_to_2comp_tb;
+integer i;
+integer aux;
+
+reg [3:0] j;
+wire [3:0] y;
+
+
+sm_to_2comp test(y, j);
+
+initial begin
+    aux = 'b0000;
+    $dumpfile("sm_to_2comp_tb.vcd");
+    $dumpvars(0, sm_to_2comp_tb);
+    
+    for(i = 0; i < 16; i = i+1) begin
+        j = aux;
+        aux = aux + 'b0001;
+        #20;
+    end
+    $display("Teste completo");
+end
+
+endmodule
+


### PR DESCRIPTION
This module takes a 4-bit wire as input and also outputs a 4-bit wire. Its function is to convert a 4-bit binary with sign-magnitude representation into a two's complement binary. Converters with the same functionality but with greater capacity will be added soon.
There's also a test-bench file.